### PR TITLE
Add privacy policy page

### DIFF
--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,8 +1,9 @@
 # app/routes/__init__.py
+from fastapi import APIRouter
+from app.routes import dashboard
 from app.routes import driver_stats
 from app.routes import live
-from fastapi import APIRouter
-from app.routes import dashboard  # Import additional route modules as needed
+from app.routes import privacy
 
 router = APIRouter()
 
@@ -10,3 +11,4 @@ router = APIRouter()
 router.include_router(dashboard.router, tags=["dashboard"])
 router.include_router(driver_stats.router, tags=["driver_stats"])
 # router.include_router(live.router, tags=["live"])
+router.include_router(privacy.router, tags=["privacy"])

--- a/app/routes/privacy.py
+++ b/app/routes/privacy.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+router = APIRouter()
+templates = Jinja2Templates(directory="app/templates")
+
+@router.get("/privacy", response_class=HTMLResponse)
+async def privacy_policy(request: Request):
+    return templates.TemplateResponse("pages/privacy_policy.html", {"request": request})

--- a/app/templates/pages/privacy_policy.html
+++ b/app/templates/pages/privacy_policy.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block title %}Privacy Policy - DataHub{% endblock %}
+
+{% block content %}
+  <h1>Privacy Policy</h1>
+  <p>
+    Safe Drive Africa is an offshoot from a research effort to improve drivers driving behaviour in non-western countries, specifically Nigeria.
+    You are taking part in this experiment to evaluate the app. This project is domiciled at the University of Aberdeen, Scotland United Kingdom.
+    Data will be stored and managed in line with all relevant University of Aberdeen policies including the Data Protection Policy, Information Security Policy, and Research Data Management Policy, Guidance and the Nigerian Data Protection Law.
+    The data collected, which is all together anonymous data, will be stored in the university shared storage drive as soon as they are received, the data may thereafter be moved to the university of Aberdeen’s Data repository and may be finally deleted after 5 years from the University of Aberdeen’s Data Repository.
+    Also note, that appropriately anonymised data may be made available to others in the future for research purposes.We collect this information to conduct academic research, manage the research project and to publish our research findings.
+    The University undertakes and publishes research under its statutory powers. These powers are laid out in the Universities (Scotland) Acts 1858 - 1966.
+  </p>
+{% endblock %}

--- a/app/templates/partials/footer.html
+++ b/app/templates/partials/footer.html
@@ -1,6 +1,6 @@
 <!-- app/templates/partials/footer.html -->
 <footer class="footer mt-auto py-3 bg-light">
     <div class="container">
-        <span class="text-muted">© 2025 SafeDrive Africa</span>
+        <span class="text-muted">© 2025 SafeDrive Africa | <a href="/privacy">Privacy Policy</a></span>
     </div>
 </footer>


### PR DESCRIPTION
## Summary
- add a privacy policy template and route
- link to the page from the site footer

## Testing
- `python -m py_compile app/routes/privacy.py app/routes/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_684c0ee9f31483328865b827fb09f85c