### PR TITLE
Add UI loading spinner and table pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ The data analysis platform for the safe drive africa
   Visualize driving data through charts, graphs, and heatmaps to quickly identify trends and patterns.
 
 
-- **Historical Data Comparison**  
+- **Historical Data Comparison**
   Compare current driving data with historical records to measure improvement or identify recurring issues.
+
+- **Loading Feedback**
+  A spinner overlay briefly appears while pages prepare data so you know the application is working.
 
 ## Getting Started
 
@@ -42,3 +45,10 @@ The data analysis platform for the safe drive africa
 
 4. **Access the Dashboard**
   Open your browser and navigate to the URL (e.g., http://localhost:8001) to view the dashboard.
+
+### Table Navigation
+
+Tables on the dashboard and the driver statistics page support client-side pagination and search.
+Use the search boxes above each table to filter by Driver ID, Driver Email, or Trip ID.
+Previous/Next buttons and page numbers below each table allow navigating between pages of up to 10 rows at a time.
+

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1,0 +1,20 @@
+#loading-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10000;
+}
+
+#loading-overlay.hidden {
+    display: none;
+}
+
+.pagination {
+    margin-bottom: 0;
+}

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -1,0 +1,103 @@
+function hideLoadingOverlay() {
+    const overlay = document.getElementById('loading-overlay');
+    if (overlay) {
+        overlay.classList.add('hidden');
+    }
+}
+
+// store paginators globally so that tables updated dynamically can refresh
+window.tablePaginators = window.tablePaginators || {};
+
+function setupTablePagination(config) {
+    const table = document.getElementById(config.tableId);
+    const searchInput = document.getElementById(config.searchInputId);
+    const prevBtn = document.getElementById(config.prevBtnId);
+    const nextBtn = document.getElementById(config.nextBtnId);
+    const pageInfo = document.getElementById(config.pageInfoId);
+    const pageNumbers = document.getElementById(config.pageNumbersId);
+    if (!table || !searchInput || !prevBtn || !nextBtn || !pageInfo) {
+        return null;
+    }
+
+    let rows = Array.from(table.querySelectorAll('tbody tr'));
+    let filteredRows = rows.slice();
+    let currentPage = 1;
+    const rowsPerPage = config.rowsPerPage || 10;
+
+    function render() {
+        const totalPages = Math.max(1, Math.ceil(filteredRows.length / rowsPerPage));
+        currentPage = Math.min(currentPage, totalPages);
+        const start = (currentPage - 1) * rowsPerPage;
+        const end = start + rowsPerPage;
+        rows.forEach(row => row.style.display = 'none');
+        filteredRows.slice(start, end).forEach(row => row.style.display = '');
+        pageInfo.textContent = `Page ${currentPage} of ${totalPages}`;
+        prevBtn.disabled = currentPage === 1;
+        nextBtn.disabled = currentPage === totalPages;
+        if (pageNumbers) {
+            pageNumbers.innerHTML = '';
+            for (let i = 1; i <= totalPages; i++) {
+                const li = document.createElement('li');
+                li.className = 'page-item' + (i === currentPage ? ' active' : '');
+                const a = document.createElement('a');
+                a.className = 'page-link';
+                a.href = '#';
+                a.textContent = i;
+                a.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    currentPage = i;
+                    render();
+                });
+                li.appendChild(a);
+                pageNumbers.appendChild(li);
+            }
+        }
+    }
+
+    function filterRows() {
+        const q = searchInput.value.toLowerCase();
+        filteredRows = rows.filter(r => r.textContent.toLowerCase().includes(q));
+        currentPage = 1;
+        render();
+    }
+
+    searchInput.addEventListener('input', filterRows);
+    prevBtn.addEventListener('click', () => { if (currentPage > 1) { currentPage--; render(); }});
+    nextBtn.addEventListener('click', () => { const totalPages = Math.ceil(filteredRows.length / rowsPerPage); if (currentPage < totalPages) { currentPage++; render(); }});
+
+    function refresh() {
+        rows = Array.from(table.querySelectorAll('tbody tr'));
+        filterRows();
+    }
+
+    render();
+    return { refresh };
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    hideLoadingOverlay();
+    window.tablePaginators.trip = setupTablePagination({
+        tableId: 'trip-table',
+        searchInputId: 'trip-search',
+        prevBtnId: 'trip-prev',
+        nextBtnId: 'trip-next',
+        pageInfoId: 'trip-page-info',
+        pageNumbersId: 'trip-pages',
+        rowsPerPage: 10
+    });
+    window.tablePaginators.driver = setupTablePagination({
+        tableId: 'driver-stats-table',
+        searchInputId: 'driver-search',
+        prevBtnId: 'driver-prev',
+        nextBtnId: 'driver-next',
+        pageInfoId: 'driver-page-info',
+        pageNumbersId: 'driver-pages',
+        rowsPerPage: 10
+    });
+});
+
+// hide overlay if page already loaded
+if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    hideLoadingOverlay();
+}
+window.addEventListener('load', hideLoadingOverlay);

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -10,7 +10,12 @@
   <link rel="stylesheet" href="/static/css/navbar.css" />
   {% block head %}{% endblock %}
 </head>
-<body>
+  <body>
+  <div id="loading-overlay">
+    <div class="spinner-border text-primary" role="status">
+      <span class="sr-only">Loading...</span>
+    </div>
+  </div>
   {% include "partials/header.html" %}
   
   <div class="container my-4">
@@ -60,6 +65,9 @@
             `;
             tableBody.appendChild(tr);
           });
+          if (window.tablePaginators && window.tablePaginators.trip) {
+            window.tablePaginators.trip.refresh();
+          }
         }
 
         // Update the driver stats table (from driver_stats.html)
@@ -77,6 +85,10 @@
             `;
             driverStatsTableBody.appendChild(tr);
           });
+
+          if (window.tablePaginators && window.tablePaginators.driver) {
+            window.tablePaginators.driver.refresh();
+          }
 
           // Update footer totals
           if (document.getElementById("drivers-total-num-trips")) {

--- a/app/templates/pages/driver_stats.html
+++ b/app/templates/pages/driver_stats.html
@@ -11,7 +11,11 @@
       Driver statistics are currently unavailable or data is still being processed. Please check back shortly.
     </div>
   {% else %}
-    <table class="table table-striped">
+    <div class="mb-2">
+      <input id="driver-search" class="form-control" placeholder="Search records" />
+      <small class="form-text text-muted">Search by Driver ID or Driver Email.</small>
+    </div>
+    <table id="driver-stats-table" class="table table-striped">
       <thead>
         <tr>
           <th>Driver ID</th>
@@ -49,6 +53,14 @@
         {% endif %}
       </tfoot>
     </table>
+    <div class="d-flex justify-content-between align-items-center">
+      <button id="driver-prev" class="btn btn-sm btn-secondary">Previous</button>
+      <ul id="driver-pages" class="pagination mb-0"></ul>
+      <button id="driver-next" class="btn btn-sm btn-secondary">Next</button>
+    </div>
+    <div class="text-center">
+      <span id="driver-page-info"></span>
+    </div>
   {% endif %}
   
   <a href="/" class="btn btn-secondary mt-3">Back to Dashboard</a>

--- a/app/templates/pages/index.html
+++ b/app/templates/pages/index.html
@@ -52,7 +52,11 @@
   
   <!-- Table: Sensor Data Per Trip (Per Driver) -->
   <h2>Sensor Data Per Trip (Per Driver)</h2>
-  <table class="table table-striped">
+  <div class="mb-2">
+    <input id="trip-search" class="form-control" placeholder="Search records" />
+    <small class="form-text text-muted">Search by Driver ID, Driver Email or Trip ID.</small>
+  </div>
+  <table id="trip-table" class="table table-striped">
     <thead>
       <tr>
         <th>Driver ID</th>
@@ -76,4 +80,12 @@
       {% endfor %}
     </tbody>
   </table>
+  <div class="d-flex justify-content-between align-items-center">
+    <button id="trip-prev" class="btn btn-sm btn-secondary">Previous</button>
+    <ul id="trip-pages" class="pagination mb-0"></ul>
+    <button id="trip-next" class="btn btn-sm btn-secondary">Next</button>
+  </div>
+  <div class="text-center">
+    <span id="trip-page-info"></span>
+  </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- implement global loading overlay
- implement client-side table search and pagination
- hook up pagination widgets for trip stats and driver stats tables
- document new table navigation features

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68544b8ca5e083328baede3ceb52deb4