### PR TITLE
Improve pagination and loading indicator

### DIFF
--- a/app/cache.py
+++ b/app/cache.py
@@ -8,7 +8,7 @@ from app.services.data_service import fetch_all_processed_data
 
 logger = logging.getLogger(__name__)
 
-REFRESH_INTERVAL = 10  # seconds
+REFRESH_INTERVAL = 30  # seconds
 
 _cached_data = None  
 _cached_checksum = None

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -4,6 +4,8 @@ function hideLoadingOverlay() {
         overlay.classList.add('hidden');
     }
 }
+// Fallback in case DOM events fail
+setTimeout(hideLoadingOverlay, 5000);
 // store paginators globally so that tables updated dynamically can refresh
 window.tablePaginators = window.tablePaginators || {};
 function setupTablePagination(config) {

--- a/app/templates/pages/driver_stats.html
+++ b/app/templates/pages/driver_stats.html
@@ -55,7 +55,9 @@
     </table>
     <div class="d-flex justify-content-between align-items-center">
       <button id="driver-prev" class="btn btn-sm btn-secondary">Previous</button>
-      <ul id="driver-pages" class="pagination mb-0"></ul>
+      <nav aria-label="Driver pages">
+        <ul id="driver-pages" class="pagination mb-0"></ul>
+      </nav>
       <button id="driver-next" class="btn btn-sm btn-secondary">Next</button>
     </div>
     <div class="text-center">

--- a/app/templates/pages/index.html
+++ b/app/templates/pages/index.html
@@ -82,7 +82,9 @@
   </table>
   <div class="d-flex justify-content-between align-items-center">
     <button id="trip-prev" class="btn btn-sm btn-secondary">Previous</button>
-    <ul id="trip-pages" class="pagination mb-0"></ul>
+    <nav aria-label="Trip pages">
+      <ul id="trip-pages" class="pagination mb-0"></ul>
+    </nav>
     <button id="trip-next" class="btn btn-sm btn-secondary">Next</button>
   </div>
   <div class="text-center">


### PR DESCRIPTION
## Summary
- add a timeout fallback so the loading overlay never stays visible forever
- wrap pagination page numbers in `<nav>` to clarify markup
- reduce background refresh frequency to lighten startup load

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685457074ae883328bc0da5a9e4e2375