### PR TITLE
Fix table search and pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,5 @@ The data analysis platform for the safe drive africa
 
 Tables on the dashboard and the driver statistics page support client-side pagination and search.
 Use the search boxes above each table to filter by Driver ID, Driver Email, or Trip ID.
+Search is case-insensitive and automatically refreshes when new live data is received.
 Previous/Next buttons and page numbers below each table allow navigating between pages of up to 10 rows at a time.

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -16,6 +16,7 @@ function setupTablePagination(config) {
     const pageInfo = document.getElementById(config.pageInfoId);
     const pageNumbers = document.getElementById(config.pageNumbersId);
     if (!table || !searchInput || !prevBtn || !nextBtn || !pageInfo) {
+        console.warn('Pagination init skipped for', config.tableId);
         return null;
     }
 
@@ -23,6 +24,26 @@ function setupTablePagination(config) {
     let filteredRows = rows.slice();
     let currentPage = 1;
     const rowsPerPage = config.rowsPerPage || 10;
+
+    function renderPageNumbers(totalPages) {
+        if (!pageNumbers) return;
+        pageNumbers.innerHTML = '';
+        for (let i = 1; i <= totalPages; i++) {
+            const li = document.createElement('li');
+            li.className = 'page-item' + (i === currentPage ? ' active' : '');
+            const a = document.createElement('a');
+            a.className = 'page-link';
+            a.href = '#';
+            a.textContent = i;
+            a.addEventListener('click', (e) => {
+                e.preventDefault();
+                currentPage = i;
+                render();
+            });
+            li.appendChild(a);
+            pageNumbers.appendChild(li);
+        }
+    }
 
     function render() {
         const totalPages = Math.max(1, Math.ceil(filteredRows.length / rowsPerPage));
@@ -34,34 +55,18 @@ function setupTablePagination(config) {
         pageInfo.textContent = `Page ${currentPage} of ${totalPages}`;
         prevBtn.disabled = currentPage === 1;
         nextBtn.disabled = currentPage === totalPages;
-        if (pageNumbers) {
-            pageNumbers.innerHTML = '';
-            for (let i = 1; i <= totalPages; i++) {
-                const li = document.createElement('li');
-                li.className = 'page-item' + (i === currentPage ? ' active' : '');
-                const a = document.createElement('a');
-                a.className = 'page-link';
-                a.href = '#';
-                a.textContent = i;
-                a.addEventListener('click', (e) => {
-                    e.preventDefault();
-                    currentPage = i;
-                    render();
-                });
-                li.appendChild(a);
-                pageNumbers.appendChild(li);
-            }
-        }
+        renderPageNumbers(totalPages);
     }
 
     function filterRows() {
-        const q = searchInput.value.toLowerCase();
-        filteredRows = rows.filter(r => r.textContent.toLowerCase().includes(q));
+        const q = searchInput.value.trim().toLowerCase();
+        filteredRows = rows.filter(r => r.innerText.toLowerCase().includes(q));
         currentPage = 1;
         render();
     }
 
     searchInput.addEventListener('input', filterRows);
+    searchInput.addEventListener('keyup', filterRows);
     prevBtn.addEventListener('click', () => { if (currentPage > 1) { currentPage--; render(); }});
     nextBtn.addEventListener('click', () => { const totalPages = Math.ceil(filteredRows.length / rowsPerPage); if (currentPage < totalPages) { currentPage++; render(); }});
     function refresh() {

--- a/main.py
+++ b/main.py
@@ -1,7 +1,10 @@
 # app/main.py
 import asyncio
 import os
-import dotenv
+try:
+    import dotenv
+except ImportError:  # pragma: no cover - optional dependency
+    dotenv = None
 from fastapi import FastAPI
 import uvicorn
 from fastapi.staticfiles import StaticFiles
@@ -10,7 +13,7 @@ from app.cache import refresh_cache_periodically
 
 # Load environment variables (for local development)
 ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
-if ENVIRONMENT == "development":
+if ENVIRONMENT == "development" and dotenv:
     dotenv.load_dotenv()
 
 app = FastAPI(


### PR DESCRIPTION
## Summary
- improve search filtering and pagination refresh logic for dynamic tables
- make dotenv optional so `python main.py` can run without extra dependencies

## Testing
- `python -m py_compile app/**/*.py main.py`
- `python main.py` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68545d18dfcc833282ce314938898c4b