### PR TITLE
Restore behaviour metrics API paths

### DIFF
--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -5,6 +5,7 @@ from app.routes import driver_stats
 from app.routes import live
 from app.routes import privacy
 from app.routes import metrics_api
+from app.routes import behaviour_metrics
 from app.routes import analysis_pages
 
 router = APIRouter()
@@ -15,4 +16,5 @@ router.include_router(driver_stats.router, tags=["driver_stats"])
 # router.include_router(live.router, tags=["live"])
 router.include_router(privacy.router, tags=["privacy"])
 router.include_router(metrics_api.router)
+router.include_router(behaviour_metrics.router)
 router.include_router(analysis_pages.router)


### PR DESCRIPTION
## Summary
- re-add `behaviour_metrics` router so legacy endpoints like `/api/behaviour_metrics` work again

## Testing
- `python -m py_compile app/routes/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68571fe657e48332b1982f59851e9563