### PR TITLE
Enhance driver/trip analysis UI

### DIFF
--- a/app/routers/analysis_pages.py
+++ b/app/routers/analysis_pages.py
@@ -13,46 +13,34 @@ from .ubpk_metrics import (
     _week_string,
     _weekly_driver_map,
     placeholder_history,
+    _driver_history,
+    driver_week_metrics,
+    driver_history_metrics,
+    trip_metrics,
 )
 
 router = APIRouter()
 templates = Jinja2Templates(directory="app/templates")
 
 
-def _driver_history(driver_id: str) -> List[Dict]:
-    payload = get_cached_data()
-    if not payload:
-        return placeholder_history(driver_id)
-    rows = payload.get("dashboard_trip_metrics", [])
-    history: Dict[str, List[float]] = {}
-    for row in rows:
-        if row.get("driverProfileId") != driver_id:
-            continue
-        start = row.get("start_time")
-        wk = None
-        if start:
-            try:
-                iso_year, iso_week, _ = date.fromisoformat(start).isocalendar()
-                wk = _week_string(iso_year, iso_week)
-            except Exception:
-                wk = None
-        if not wk:
-            continue
-        history.setdefault(wk, []).append(row.get("invalidSensorDataCount", 0) / max(1, row.get("totalSensorDataCount", 1)))
-
-    if not history:
-        return placeholder_history(driver_id)
-    return [
-        {"week": week, "ubpk": sum(vals) / len(vals)} for week, vals in sorted(history.items())
-    ]
-
-
 @router.get("/driver/{driver_id}", response_class=HTMLResponse)
 async def driver_analysis_home(request: Request, driver_id: str):
-    weeks = [h["week"] for h in _driver_history(driver_id)]
+    # Current week metrics for initial display
+    today = date.today()
+    year, wk = today.isocalendar()[:2]
+    driver_map = _weekly_driver_map(year, wk)
+    vals = driver_map.get(driver_id)
+    current_metrics = None
+    if vals:
+        current_metrics = {
+            "week": _week_string(year, wk),
+            "ubpk": sum(vals) / len(vals),
+            "numTrips": len(vals),
+        }
+
     return templates.TemplateResponse(
         "pages/driver_analysis.html",
-        {"request": request, "driver_id": driver_id, "weeks": weeks},
+        {"request": request, "driver_id": driver_id, "current": current_metrics},
     )
 
 
@@ -89,4 +77,19 @@ async def driver_history_page(request: Request, driver_id: str):
     return templates.TemplateResponse(
         "pages/driver_history.html",
         {"request": request, "driver_id": driver_id, "history": history},
+    )
+
+
+@router.get("/trip/{trip_id}", response_class=HTMLResponse)
+async def trip_analysis_page(request: Request, trip_id: str):
+    try:
+        metrics = trip_metrics(trip_id)
+    except HTTPException as exc:
+        if exc.status_code == 404:
+            metrics = None
+        else:
+            raise
+    return templates.TemplateResponse(
+        "pages/trip_analysis.html",
+        {"request": request, "trip_id": trip_id, "metrics": metrics},
     )

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -50,11 +50,18 @@
           tableBody.innerHTML = "";
           data.aggregates.driver_trip_sensor_stats.forEach(row => {
             const tr = document.createElement("tr");
+            let week = row.week;
+            if (!week && row.start_time) {
+              const dt = new Date(row.start_time);
+              const onejan = new Date(dt.getFullYear(),0,1);
+              const weekNo = Math.ceil((((dt - onejan) / 86400000) + onejan.getDay()+1)/7);
+              week = `${dt.getFullYear()}-W${String(weekNo).padStart(2,'0')}`;
+            }
             tr.innerHTML = `
               <td><a href="/analysis/driver/${row.driverProfileId}">${row.driverProfileId}</a></td>
               <td>${row.driverEmail}</td>
               <td><a href="/analysis/trip/${row.tripId}">${row.tripId}</a></td>
-              <td>${row.week || ''}</td>
+              <td>${week || ''}</td>
               <td>${row.totalSensorDataCount}</td>
               <td>${row.invalidSensorDataCount}</td>
               <td>${row.validSensorDataCount}</td>

--- a/app/templates/pages/driver_analysis.html
+++ b/app/templates/pages/driver_analysis.html
@@ -2,16 +2,70 @@
 {% block title %}Driver {{ driver_id }} Analysis{% endblock %}
 {% block content %}
 <h1>Driver {{ driver_id }} Analysis</h1>
-<form method="get" action="/analysis/driver/{{ driver_id }}/trend">
-  <div class="form-group">
-    <label for="week">Week</label>
-    <select class="form-control" id="week" name="week">
-      {% for w in weeks %}
-        <option value="{{ w }}">{{ w }}</option>
-      {% endfor %}
-    </select>
-  </div>
-  <button type="submit" class="btn btn-primary">Show Trend</button>
-  <a href="/analysis/driver/{{ driver_id }}/history" class="btn btn-secondary">History</a>
-</form>
+<div>
+  {% if current %}
+  <p>Current Week ({{ current.week }}) UBPK: <span id="current-ubpk">{{ '%.3f'|format(current.ubpk) }}</span></p>
+  {% else %}
+  <p>No trips for the current week.</p>
+  {% endif %}
+</div>
+<div class="form-group">
+  <label for="week-select">Week</label>
+  <select id="week-select" class="form-control"></select>
+</div>
+<canvas id="trend-chart" height="200"></canvas>
+<p>t-test p-value: <span id="p-value"></span></p>
+<div id="loading" class="spinner" style="display:none;">Loading...</div>
+{% endblock %}
+{% block scripts %}
+{{ super() }}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const select = document.getElementById('week-select');
+    const loading = document.getElementById('loading');
+    let chart = null;
+    function renderChart(history) {
+      const ctx = document.getElementById('trend-chart').getContext('2d');
+      const labels = history.map(h => h.week);
+      const data = history.map(h => h.ubpk);
+      const colors = history.map((h,i)=> i>=history.length-2 ? 'rgba(255,99,132,0.6)' : 'rgba(54,162,235,0.6)');
+      if(chart){ chart.destroy(); }
+      chart = new Chart(ctx, {
+        type: 'bar',
+        data: {labels, datasets:[{label:'UBPK', data, backgroundColor:colors}]},
+        options: {scales:{y:{beginAtZero:true}}}
+      });
+    }
+    function loadHistory(){
+      loading.style.display='block';
+      fetch('/metrics/behavior/driver/{{ driver_id }}/history')
+        .then(r=>r.json())
+        .then(hist=>{
+          select.innerHTML='';
+          hist.forEach(h=>{
+            const opt=document.createElement('option');
+            opt.value=h.week; opt.textContent=h.week; select.appendChild(opt);
+          });
+          if(hist.length){ select.value=hist[hist.length-1].week; }
+          renderChart(hist);
+          loading.style.display='none';
+        })
+        .catch(()=>{loading.style.display='none';});
+    }
+    function updateTrend(week){
+      loading.style.display='block';
+      fetch(`/analysis/driver/{{ driver_id }}/trend?week=${week}`,{headers:{'accept':'application/json'}})
+        .then(r=>r.json())
+        .then(d=>{
+          renderChart(d.history);
+          if(d.p_value!==undefined){document.getElementById('p-value').textContent=d.p_value.toFixed(3);} else {document.getElementById('p-value').textContent='';}
+          loading.style.display='none';
+        })
+        .catch(()=>{loading.style.display='none';});
+    }
+    select.addEventListener('change', e=> updateTrend(e.target.value));
+    loadHistory();
+  });
+</script>
 {% endblock %}

--- a/app/templates/pages/trip_analysis.html
+++ b/app/templates/pages/trip_analysis.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}Trip {{ trip_id }} Analysis{% endblock %}
+{% block content %}
+<h1>Trip {{ trip_id }} Analysis</h1>
+{% if metrics %}
+<ul>
+  <li>Driver: <a href="/analysis/driver/{{ metrics.driverProfileId }}">{{ metrics.driverProfileId }}</a></li>
+  <li>Start Time: {{ metrics.start_time }}</li>
+  <li>Total Sensor Records: {{ metrics.totalSensorDataCount }}</li>
+  <li>Invalid Sensor Records: {{ metrics.invalidSensorDataCount }}</li>
+  <li>UBPK: {{ '%.3f'|format(metrics.ubpk) if metrics.ubpk is not none else 'N/A' }}</li>
+</ul>
+{% else %}
+<p>No data found for this trip.</p>
+{% endif %}
+<a href="/" class="btn btn-secondary mt-3">Back</a>
+{% endblock %}

--- a/tests/test_analysis_pages.py
+++ b/tests/test_analysis_pages.py
@@ -31,3 +31,27 @@ def test_history_page():
         resp = client.get("/analysis/driver/d1/history")
     assert resp.status_code == 200
     assert "UBPK History" in resp.text
+
+
+def test_dashboard_table_columns():
+    with patch("app.cache.get_cached_data", return_value=sample_data):
+        resp = client.get("/")
+    assert resp.status_code == 200
+    assert "Driver ID" in resp.text and "Week" in resp.text
+    assert "/analysis/driver/d1" in resp.text
+
+
+def test_driver_analysis_page_selector():
+    with patch("app.cache.get_cached_data", return_value=sample_data):
+        resp = client.get("/analysis/driver/d1")
+    assert resp.status_code == 200
+    assert "id=\"week-select\"" in resp.text
+    assert f"/metrics/behavior/driver/d1/history" in resp.text
+
+
+def test_trip_analysis_page():
+    with patch("app.cache.get_cached_data", return_value=sample_data):
+        resp = client.get("/analysis/trip/t1")
+    assert resp.status_code == 200
+    assert "Trip t1 Analysis" in resp.text
+    assert "/analysis/driver/d1" in resp.text

--- a/tests/test_ubpk.py
+++ b/tests/test_ubpk.py
@@ -72,3 +72,24 @@ def test_improvement_analysis():
     assert resp.status_code == 200
     body = resp.json()
     assert "p_value" in body and "mean_difference" in body
+
+
+def test_driver_week_metrics():
+    with patch("app.cache.get_cached_data", return_value=sample_data):
+        resp = client.get("/metrics/behavior/driver/d1?week=2024-W23")
+    assert resp.status_code == 200
+    assert resp.json()["ubpk"] == 0.2
+
+
+def test_driver_history_metrics():
+    with patch("app.cache.get_cached_data", return_value=sample_data):
+        resp = client.get("/metrics/behavior/driver/d1/history")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+def test_single_trip_metrics():
+    with patch("app.cache.get_cached_data", return_value=sample_data):
+        resp = client.get("/metrics/behavior/trip/t1")
+    assert resp.status_code == 200
+    assert resp.json()["tripId"] == "t1"


### PR DESCRIPTION
## Summary
- compute ISO week server-side for dashboard rows
- expose driver/week history metrics endpoints
- add driver/trip analysis templates with charts
- populate dashboard table from SSE with computed week
- extend test suite for new pages and endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68575670c9548332ad532e260c0584e6