### PR TITLE
Fix week cell rendering

### DIFF
--- a/app/templates/pages/index.html
+++ b/app/templates/pages/index.html
@@ -70,7 +70,7 @@
           <td><a href="/analysis/driver/{{ row.driverProfileId }}">{{ row.driverProfileId }}</a></td>
           <td>{{ row.driverEmail }}</td>
           <td><a href="/analysis/trip/{{ row.tripId }}">{{ row.tripId }}</a></td>
-          <td>{{ row.week }}</td>
+          <td>{{ row.week or '' }}</td>
           <td>{{ row.totalSensorDataCount }}</td>
           <td>{{ row.invalidSensorDataCount }}</td>
           <td>{{ row.validSensorDataCount }}</td>


### PR DESCRIPTION
## Summary
- ensure week column never shows 'None'

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685760bff5fc8332898fc94e27925661