### PR TITLE
Add dynamic week selector and trip/driver views

### DIFF
--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -1,0 +1,35 @@
+(document=>{
+  document.addEventListener('DOMContentLoaded', ()=>{
+    const weekSel=document.getElementById('week-selector');
+    const tbody=document.getElementById('trips-tbody');
+    if(!weekSel||!tbody) return;
+    const load=()=>{
+      const week=weekSel.value;
+      weekSel.disabled=true;
+      tbody.innerHTML='<tr><td colspan="6">Loading...</td></tr>';
+      fetch(`/metrics/behavior/trips?week=${week}`)
+        .then(r=>r.ok?r.json():[])
+        .then(rows=>{
+          tbody.innerHTML='';
+          if(!rows.length){
+            tbody.innerHTML='<tr><td colspan="6">No data for this week</td></tr>';
+          }else{
+            rows.forEach(row=>{
+              const tr=document.createElement('tr');
+              tr.innerHTML=`<td><a href="/analysis/trip/${row.tripId}">${row.tripId}</a></td>
+                <td><a href="/analysis/driver/${row.driverId}">${row.driverId}</a></td>
+                <td>${row.week}</td>
+                <td>${row.totalUnsafeCount}</td>
+                <td>${row.distanceKm}</td>
+                <td>${row.ubpk}</td>`;
+              tbody.appendChild(tr);
+            });
+          }
+        })
+        .catch(()=>{tbody.innerHTML='<tr><td colspan="6">No data for this week</td></tr>';})
+        .finally(()=>{weekSel.disabled=false;});
+    };
+    weekSel.addEventListener('change',load);
+    load();
+  });
+})(document);

--- a/app/static/js/driver_analysis.js
+++ b/app/static/js/driver_analysis.js
@@ -1,0 +1,45 @@
+document.addEventListener('DOMContentLoaded',()=>{
+  const select=document.getElementById('week-select');
+  const loading=document.getElementById('loading');
+  const pval=document.getElementById('p-value');
+  const ctx=document.getElementById('trend-chart').getContext('2d');
+  let chart=null;
+  function isoWeeks(){
+    const now=new Date();
+    const list=[];
+    for(let i=0;i<8;i++){
+      const d=new Date(now);d.setDate(d.getDate()-i*7);
+      list.push(window.isoWeekString?window.isoWeekString(d):(function(d){const dt=new Date(Date.UTC(d.getFullYear(),d.getMonth(),d.getDate()));const day=dt.getUTCDay()||7;dt.setUTCDate(dt.getUTCDate()+4-day);const yearStart=new Date(Date.UTC(dt.getUTCFullYear(),0,1));const week=Math.ceil((((dt-yearStart)/86400000)+1)/7);return `${dt.getUTCFullYear()}-W${String(week).padStart(2,'0')}`;})(d));
+    }
+    return list;
+  }
+  function populate(){
+    const weeks=isoWeeks();
+    select.innerHTML='';
+    weeks.forEach(w=>{const o=document.createElement('option');o.value=w;o.textContent=w;select.appendChild(o);});
+    select.value=weeks[0];
+  }
+  function renderChart(vals){
+    const labels=vals.map((_,i)=>i+1);
+    if(chart) chart.destroy();
+    chart=new Chart(ctx,{type:'line',data:{labels,datasets:[{label:'UBPK',data:vals}]},options:{scales:{y:{beginAtZero:true}}}});
+  }
+  function load(){
+    const week=select.value;
+    loading.style.display='block';
+    fetch(`/metrics/behavior/driver/${driverId}?week=${week}`)
+      .then(r=>r.json())
+      .then(d=>{
+        renderChart(d.ubpkValues||[]);
+        fetch(`/metrics/behavior/driver/${driverId}/improvement?week=${week}`)
+          .then(r=>r.json())
+          .then(im=>{pval.textContent=`${im.pValue.toFixed(3)} / ${im.meanDifference.toFixed(3)}`;})
+          .catch(()=>{pval.textContent='';})
+          .finally(()=>{loading.style.display='none';});
+      })
+      .catch(()=>{loading.style.display='none';});
+  }
+  populate();
+  select.addEventListener('change',load);
+  load();
+});

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const select = document.getElementById('week-selector');
+  if (!select) return;
+  const now = new Date();
+  function isoWeekString(d){
+    const dt = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+    const dayNum = dt.getUTCDay() || 7;
+    dt.setUTCDate(dt.getUTCDate() + 4 - dayNum);
+    const yearStart = new Date(Date.UTC(dt.getUTCFullYear(),0,1));
+    const weekNo = Math.ceil((((dt - yearStart) / 86400000) + 1)/7);
+    return `${dt.getUTCFullYear()}-W${String(weekNo).padStart(2,'0')}`;
+  }
+  window.isoWeekString = isoWeekString;
+  const weeks=[];
+  for(let i=0;i<8;i++){
+    const d=new Date(now); d.setDate(d.getDate()-i*7);
+    weeks.push(isoWeekString(d));
+  }
+  select.innerHTML=weeks.map(w=>`<option value="${w}">${w}</option>`).join('');
+  select.value=isoWeekString(now);
+  select.dispatchEvent(new Event('change'));
+});

--- a/app/static/js/trip_analysis.js
+++ b/app/static/js/trip_analysis.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded',()=>{
+  const tableBody=document.querySelector('#trip-summary tbody');
+  const loading=document.getElementById('trip-loading');
+  const error=document.getElementById('trip-error');
+  if(!tableBody) return;
+  loading.style.display='block';
+  fetch(`/metrics/behavior/trip/${tripId}/ubpk`)
+    .then(r=>r.ok?r.json():null)
+    .then(data=>{
+      loading.style.display='none';
+      if(!data){error.style.display='block';return;}
+      const rows=[
+        ['Week',data.week],
+        ['Week Start',data.weekStart],
+        ['Week End',data.weekEnd],
+        ['Total Unsafe Count',data.totalUnsafeCount],
+        ['Distance (km)',data.distanceKm],
+        ['UBPK',data.ubpk]
+      ];
+      rows.forEach(([k,v])=>{
+        const tr=document.createElement('tr');
+        tr.innerHTML=`<th>${k}</th><td>${v}</td>`;
+        tableBody.appendChild(tr);
+      });
+    })
+    .catch(()=>{loading.style.display='none'; error.style.display='block';});
+});

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,8 +12,12 @@
 </head>
 <body>
   {% include "partials/header.html" %}
-  
+
   <div class="container my-4">
+    <div class="form-group">
+      <label for="week-selector">Week</label>
+      <select id="week-selector" class="form-control w-auto d-inline-block"></select>
+    </div>
     {% block content %}{% endblock %}
   </div>
   

--- a/app/templates/pages/driver_analysis.html
+++ b/app/templates/pages/driver_analysis.html
@@ -20,52 +20,6 @@
 {% block scripts %}
 {{ super() }}
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<script>
-  document.addEventListener('DOMContentLoaded', () => {
-    const select = document.getElementById('week-select');
-    const loading = document.getElementById('loading');
-    let chart = null;
-    function renderChart(history) {
-      const ctx = document.getElementById('trend-chart').getContext('2d');
-      const labels = history.map(h => h.week);
-      const data = history.map(h => h.ubpk);
-      const colors = history.map((h,i)=> i>=history.length-2 ? 'rgba(255,99,132,0.6)' : 'rgba(54,162,235,0.6)');
-      if(chart){ chart.destroy(); }
-      chart = new Chart(ctx, {
-        type: 'bar',
-        data: {labels, datasets:[{label:'UBPK', data, backgroundColor:colors}]},
-        options: {scales:{y:{beginAtZero:true}}}
-      });
-    }
-    function loadHistory(){
-      loading.style.display='block';
-      fetch('/metrics/behavior/driver/{{ driver_id }}/history')
-        .then(r=>r.json())
-        .then(hist=>{
-          select.innerHTML='';
-          hist.forEach(h=>{
-            const opt=document.createElement('option');
-            opt.value=h.week; opt.textContent=h.week; select.appendChild(opt);
-          });
-          if(hist.length){ select.value=hist[hist.length-1].week; }
-          renderChart(hist);
-          loading.style.display='none';
-        })
-        .catch(()=>{loading.style.display='none';});
-    }
-    function updateTrend(week){
-      loading.style.display='block';
-      fetch(`/analysis/driver/{{ driver_id }}/trend?week=${week}`,{headers:{'accept':'application/json'}})
-        .then(r=>r.json())
-        .then(d=>{
-          renderChart(d.history);
-          if(d.p_value!==undefined){document.getElementById('p-value').textContent=d.p_value.toFixed(3);} else {document.getElementById('p-value').textContent='';}
-          loading.style.display='none';
-        })
-        .catch(()=>{loading.style.display='none';});
-    }
-    select.addEventListener('change', e=> updateTrend(e.target.value));
-    loadHistory();
-  });
-</script>
+<script src="/static/js/driver_analysis.js"></script>
+<script>const driverId = "{{ driver_id }}";</script>
 {% endblock %}

--- a/app/templates/pages/index.html
+++ b/app/templates/pages/index.html
@@ -50,32 +50,24 @@
     </div>
   </div>
   
-  <!-- Table: Sensor Data Per Trip (Per Driver) -->
-  <h2>Sensor Data Per Trip (Per Driver)</h2>
-  <table class="table table-striped">
+  <!-- Trips UBPK Table -->
+  <h2>Trips</h2>
+  <table class="table table-striped" id="trips-table">
     <thead>
       <tr>
-        <th>Driver ID</th>
-        <th>Driver Email</th>
         <th>Trip ID</th>
+        <th>Driver ID</th>
         <th>Week</th>
-        <th>Total</th>
-        <th>Invalid</th>
-        <th>Valid</th>
+        <th>Total Unsafe Count</th>
+        <th>Distance (km)</th>
+        <th>UBPK</th>
       </tr>
     </thead>
-    <tbody id="trip-table-body">
-      {% for row in aggregates.driver_trip_sensor_stats %}
-        <tr>
-          <td><a href="/analysis/driver/{{ row.driverProfileId }}">{{ row.driverProfileId }}</a></td>
-          <td>{{ row.driverEmail }}</td>
-          <td><a href="/analysis/trip/{{ row.tripId }}">{{ row.tripId }}</a></td>
-          <td>{{ row.week or '' }}</td>
-          <td>{{ row.totalSensorDataCount }}</td>
-          <td>{{ row.invalidSensorDataCount }}</td>
-          <td>{{ row.validSensorDataCount }}</td>
-        </tr>
-      {% endfor %}
-    </tbody>
+    <tbody id="trips-tbody"></tbody>
   </table>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script src="/static/js/dashboard.js"></script>
 {% endblock %}

--- a/app/templates/pages/trip_analysis.html
+++ b/app/templates/pages/trip_analysis.html
@@ -2,16 +2,16 @@
 {% block title %}Trip {{ trip_id }} Analysis{% endblock %}
 {% block content %}
 <h1>Trip {{ trip_id }} Analysis</h1>
-{% if metrics %}
-<ul>
-  <li>Driver: <a href="/analysis/driver/{{ metrics.driverProfileId }}">{{ metrics.driverProfileId }}</a></li>
-  <li>Start Time: {{ metrics.start_time }}</li>
-  <li>Total Sensor Records: {{ metrics.totalSensorDataCount }}</li>
-  <li>Invalid Sensor Records: {{ metrics.invalidSensorDataCount }}</li>
-  <li>UBPK: {{ '%.3f'|format(metrics.ubpk) if metrics.ubpk is not none else 'N/A' }}</li>
-</ul>
-{% else %}
-<p>No data found for this trip.</p>
-{% endif %}
+<table class="table table-bordered w-auto" id="trip-summary">
+  <tbody></tbody>
+</table>
+<div id="trip-loading" style="display:none">Loading...</div>
+<div id="trip-error" class="text-danger" style="display:none">No data found for this trip.</div>
 <a href="/" class="btn btn-secondary mt-3">Back</a>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script src="/static/js/trip_analysis.js"></script>
+<script>const tripId = "{{ trip_id }}";</script>
 {% endblock %}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'jsdom',
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "sda-frontend",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.0",
+    "jsdom": "^22.1.0"
+  }
+}

--- a/tests/frontend/dashboard.test.js
+++ b/tests/frontend/dashboard.test.js
@@ -1,0 +1,29 @@
+import {JSDOM} from 'jsdom';
+import fs from 'fs';
+
+const html=fs.readFileSync('app/templates/pages/index.html','utf8');
+
+jest.spyOn(global,'fetch');
+
+beforeEach(()=>{
+  fetch.mockResolvedValue({ok:true,json:async()=>[]});
+  document.body.innerHTML=new JSDOM(html).window.document.body.innerHTML;
+  // insert basic week selector options
+  const sel=document.getElementById('week-selector');
+  sel.innerHTML='<option value="2025-W01">2025-W01</option>';
+});
+
+test('changing week selector calls API',async()=>{
+  await import('../../app/static/js/dashboard.js');
+  const sel=document.getElementById('week-selector');
+  sel.value='2025-W01';
+  sel.dispatchEvent(new Event('change'));
+  expect(fetch).toHaveBeenCalledWith('/metrics/behavior/trips?week=2025-W01');
+});
+
+test('table updates from response',async()=>{
+  fetch.mockResolvedValueOnce({ok:true,json:async()=>[{tripId:'t1',driverId:'d1',week:'2025-W01',totalUnsafeCount:1,distanceKm:10,ubpk:0.1}]});
+  await import('../../app/static/js/dashboard.js');
+  const row=document.querySelector('#trips-tbody tr');
+  expect(row.querySelector('td').textContent).toBe('t1');
+});

--- a/tests/frontend/driver_analysis.test.js
+++ b/tests/frontend/driver_analysis.test.js
@@ -1,0 +1,23 @@
+import {JSDOM} from 'jsdom';
+import fs from 'fs';
+
+const html=fs.readFileSync('app/templates/pages/driver_analysis.html','utf8');
+
+jest.spyOn(global,'fetch');
+
+beforeEach(()=>{
+  fetch.mockResolvedValue({ok:true,json:async()=>({ubpkValues:[],numTrips:1,meanUBPK:0.1})});
+  document.body.innerHTML=new JSDOM(html).window.document.body.innerHTML;
+  document.body.innerHTML+=`<script>const driverId='d1';</script>`;
+  const sel=document.getElementById('week-select');
+  sel.innerHTML='<option value="2025-W01">2025-W01</option>';
+});
+
+test('shows improvement numbers',async()=>{
+  fetch
+    .mockResolvedValueOnce({ok:true,json:async()=>({ubpkValues:[0.1,0.2]})})
+    .mockResolvedValueOnce({ok:true,json:async()=>({pValue:0.05,meanDifference:-0.1})});
+  await import('../../app/static/js/driver_analysis.js');
+  const text=document.getElementById('p-value').textContent;
+  expect(text).toContain('0.05');
+});


### PR DESCRIPTION
## Summary
- add global week selector and helper JS
- create dynamic trips table on dashboard
- load UBPK data on trip analysis page
- fetch driver metrics and improvement analysis with Chart.js
- add Jest unit tests setup

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68588f4ea1788332999bc55f913e08a4