### PR TITLE
Revert last dashboard update

### DIFF
--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -1,56 +1,35 @@
-function getLastNWeeks(n) {
-  const weeks = [];
-  const today = new Date();
-  for (let i = 0; i < n; i++) {
-    const dt = new Date(today);
-    dt.setDate(dt.getDate() - 7 * i);
-    const [year, week] = dt.toISOString().split('T')[0]
-      .split('-')
-      .map((v, idx) => idx === 1 ? String(Math.ceil((+v - 1 + ((new Date(dt.getFullYear(), 0, 1).getDay() + 6) % 7)) / 7)).padStart(2, '0') : v);
-    weeks.push(`${year}-W${week}`);
-  }
-  return weeks;
-}
-
-document.addEventListener('DOMContentLoaded', () => {
-  const selector = document.getElementById('week-selector');
-  const tableBody = document.querySelector('#trip-table-body');
-  if (!selector || !tableBody) return;
-  getLastNWeeks(8).forEach(wk => {
-    const opt = document.createElement('option');
-    opt.value = wk; opt.textContent = wk;
-    selector.appendChild(opt);
+(document=>{
+  document.addEventListener('DOMContentLoaded', ()=>{
+    const weekSel=document.getElementById('week-selector');
+    const tbody=document.getElementById('trips-tbody');
+    if(!weekSel||!tbody) return;
+    const load=()=>{
+      const week=weekSel.value;
+      weekSel.disabled=true;
+      tbody.innerHTML='<tr><td colspan="6">Loading...</td></tr>';
+      fetch(`/metrics/behavior/trips?week=${week}`)
+        .then(r=>r.ok?r.json():[])
+        .then(rows=>{
+          tbody.innerHTML='';
+          if(!rows.length){
+            tbody.innerHTML='<tr><td colspan="6">No data for this week</td></tr>';
+          }else{
+            rows.forEach(row=>{
+              const tr=document.createElement('tr');
+              tr.innerHTML=`<td><a href="/analysis/trip/${row.tripId}">${row.tripId}</a></td>
+                <td><a href="/analysis/driver/${row.driverId}">${row.driverId}</a></td>
+                <td>${row.week}</td>
+                <td>${row.totalUnsafeCount}</td>
+                <td>${row.distanceKm}</td>
+                <td>${row.ubpk}</td>`;
+              tbody.appendChild(tr);
+            });
+          }
+        })
+        .catch(()=>{tbody.innerHTML='<tr><td colspan="6">No data for this week</td></tr>';})
+        .finally(()=>{weekSel.disabled=false;});
+    };
+    weekSel.addEventListener('change',load);
+    load();
   });
-  selector.value = getLastNWeeks(1)[0];
-  loadTrips(selector.value);
-  selector.addEventListener('change', () => loadTrips(selector.value));
-});
-
-async function loadTrips(week) {
-  const tableBody = document.querySelector('#trip-table-body');
-  tableBody.innerHTML = '<tr><td colspan="6">Loading…</td></tr>';
-  try {
-    const res = await fetch(`/metrics/behavior/trips?week=${week}`);
-    if (!res.ok) throw new Error('No data');
-    const trips = await res.json();
-    if (trips.length === 0) {
-      tableBody.innerHTML = '<tr><td colspan="6">No data for this week</td></tr>';
-      return;
-    }
-    tableBody.innerHTML = '';
-    trips.forEach(trip => {
-      const tr = document.createElement('tr');
-      tr.innerHTML = `
-        <td><a href="/analysis/trip/${trip.tripId}">${trip.tripId}</a></td>
-        <td><a href="/analysis/driver/${trip.driverProfileId}">${trip.driverProfileId}</a></td>
-        <td>${trip.week}</td>
-        <td>${trip.totalUnsafeCount}</td>
-        <td>${trip.distanceKm.toFixed(2)}</td>
-        <td>${trip.ubpk.toFixed(3)}</td>
-      `;
-      tableBody.appendChild(tr);
-    });
-  } catch (e) {
-    tableBody.innerHTML = '<tr><td colspan="6">No data for this week</td></tr>';
-  }
-}
+})(document);

--- a/app/templates/pages/index.html
+++ b/app/templates/pages/index.html
@@ -4,8 +4,6 @@
 
 {% block content %}
   <h1 class="mb-4">Experiment Data Overview</h1>
-  <label for="week-selector">Week</label>
-  <select id="week-selector" class="form-select form-select-sm"></select>
   
   
   <!-- Summary Cards with element IDs for live updates -->
@@ -65,13 +63,11 @@
         <th>UBPK</th>
       </tr>
     </thead>
-    <tbody id="trip-table-body">
-      <tr><td colspan="6">No data for this week</td></tr>
-    </tbody>
+    <tbody id="trips-tbody"></tbody>
   </table>
 {% endblock %}
 
 {% block scripts %}
 {{ super() }}
-<script src="{{ url_for('static', path='js/dashboard.js') }}"></script>
+<script src="/static/js/dashboard.js"></script>
 {% endblock %}

--- a/tests/frontend/dashboard.test.js
+++ b/tests/frontend/dashboard.test.js
@@ -22,8 +22,8 @@ test('changing week selector calls API',async()=>{
 });
 
 test('table updates from response',async()=>{
-  fetch.mockResolvedValueOnce({ok:true,json:async()=>[{tripId:'t1',driverProfileId:'d1',week:'2025-W01',totalUnsafeCount:1,distanceKm:10,ubpk:0.1}]});
+  fetch.mockResolvedValueOnce({ok:true,json:async()=>[{tripId:'t1',driverId:'d1',week:'2025-W01',totalUnsafeCount:1,distanceKm:10,ubpk:0.1}]});
   await import('../../app/static/js/dashboard.js');
-  const row=document.querySelector('#trip-table-body tr');
+  const row=document.querySelector('#trips-tbody tr');
   expect(row.querySelector('td').textContent).toBe('t1');
 });


### PR DESCRIPTION
## Summary
- revert merge commit that added week selector and trip data loading

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68589cc2a3108332a66d726a01fc9606